### PR TITLE
Further optimize albegra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `Innmind\Math\Geometry\Angle\Radian::cosine()`
 - `Innmind\Math\Geometry\Angle\Radian::sine()`
 - `Innmind\Math\Geometry\Angle\Radian::tangent()`
+- `Innmind\Math\Polynom\Degree::is()`
 
 ### Changed
 

--- a/src/Algebra/Absolute.php
+++ b/src/Algebra/Absolute.php
@@ -22,7 +22,7 @@ final class Absolute implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of(\abs($this->number->raw()->value()));
     }

--- a/src/Algebra/Absolute.php
+++ b/src/Algebra/Absolute.php
@@ -22,9 +22,9 @@ final class Absolute implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
-        return Native::of(\abs($this->number->raw()->value()));
+        return Native::of(\abs($this->number->memoize()->value()));
     }
 
     #[\Override]

--- a/src/Algebra/Absolute.php
+++ b/src/Algebra/Absolute.php
@@ -22,15 +22,9 @@ final class Absolute implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return \abs($this->number->value());
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of(\abs($this->number->raw()->value()));
     }
 
     #[\Override]

--- a/src/Algebra/Absolute.php
+++ b/src/Algebra/Absolute.php
@@ -24,7 +24,7 @@ final class Absolute implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->result()->value();
+        return \abs($this->number->value());
     }
 
     #[\Override]
@@ -49,17 +49,5 @@ final class Absolute implements Implementation
     public function format(): string
     {
         return '('.$this->toString().')';
-    }
-
-    private function result(): Implementation
-    {
-        return $this->compute($this->number);
-    }
-
-    private function compute(Implementation $number): Implementation
-    {
-        return Native::of(
-            \abs($number->value()),
-        );
     }
 }

--- a/src/Algebra/Absolute.php
+++ b/src/Algebra/Absolute.php
@@ -28,9 +28,9 @@ final class Absolute implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/Addition.php
+++ b/src/Algebra/Addition.php
@@ -29,7 +29,7 @@ final class Addition implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
         return $this->sum();
     }
@@ -37,7 +37,7 @@ final class Addition implements Implementation
     public function sum(): Native
     {
         return Native::of(
-            $this->a->raw()->value() + $this->b->raw()->value(),
+            $this->a->memoize()->value() + $this->b->memoize()->value(),
         );
     }
 

--- a/src/Algebra/Addition.php
+++ b/src/Algebra/Addition.php
@@ -35,12 +35,12 @@ final class Addition implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return $this->sum();
     }
 
-    public function sum(): Implementation
+    public function sum(): Native|Value
     {
         return Native::of(
             $this->a->value() + $this->b->value(),

--- a/src/Algebra/Addition.php
+++ b/src/Algebra/Addition.php
@@ -29,12 +29,6 @@ final class Addition implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return $this->sum()->value();
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
         return $this->sum();
@@ -43,7 +37,7 @@ final class Addition implements Implementation
     public function sum(): Native|Value
     {
         return Native::of(
-            $this->a->value() + $this->b->value(),
+            $this->a->raw()->value() + $this->b->raw()->value(),
         );
     }
 

--- a/src/Algebra/Addition.php
+++ b/src/Algebra/Addition.php
@@ -29,12 +29,12 @@ final class Addition implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return $this->sum();
     }
 
-    public function sum(): Native|Value
+    public function sum(): Native
     {
         return Native::of(
             $this->a->raw()->value() + $this->b->raw()->value(),

--- a/src/Algebra/AppliedFunc.php
+++ b/src/Algebra/AppliedFunc.php
@@ -24,7 +24,7 @@ final class AppliedFunc implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
         $result = ($this->func)($this->x);
 
@@ -35,7 +35,7 @@ final class AppliedFunc implements Implementation
          * @psalm-suppress InaccessibleProperty
          */
         return (\Closure::bind(
-            static fn(Number $result) => $result->implementation->raw(),
+            static fn(Number $result) => $result->implementation->memoize(),
             null,
             Number::class,
         ))($result);

--- a/src/Algebra/AppliedFunc.php
+++ b/src/Algebra/AppliedFunc.php
@@ -30,9 +30,9 @@ final class AppliedFunc implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/AppliedFunc.php
+++ b/src/Algebra/AppliedFunc.php
@@ -24,7 +24,7 @@ final class AppliedFunc implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         $result = ($this->func)($this->x);
 

--- a/src/Algebra/AppliedFunc.php
+++ b/src/Algebra/AppliedFunc.php
@@ -24,15 +24,21 @@ final class AppliedFunc implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return ($this->func)($this->x)->value();
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        $result = ($this->func)($this->x);
+
+        /**
+         * @psalm-suppress PossiblyNullFunctionCall
+         * @psalm-suppress ImpureFunctionCall
+         * @psalm-suppress MixedReturnStatement
+         * @psalm-suppress InaccessibleProperty
+         */
+        return (\Closure::bind(
+            static fn(Number $result) => $result->implementation->raw(),
+            null,
+            Number::class,
+        ))($result);
     }
 
     #[\Override]

--- a/src/Algebra/Ceil.php
+++ b/src/Algebra/Ceil.php
@@ -22,7 +22,7 @@ final class Ceil implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of(\ceil($this->number->raw()->value()));
     }

--- a/src/Algebra/Ceil.php
+++ b/src/Algebra/Ceil.php
@@ -22,9 +22,9 @@ final class Ceil implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
-        return Native::of(\ceil($this->number->raw()->value()));
+        return Native::of(\ceil($this->number->memoize()->value()));
     }
 
     #[\Override]
@@ -36,7 +36,7 @@ final class Ceil implements Implementation
     #[\Override]
     public function toString(): string
     {
-        return \var_export($this->raw()->value(), true);
+        return \var_export($this->memoize()->value(), true);
     }
 
     #[\Override]

--- a/src/Algebra/Ceil.php
+++ b/src/Algebra/Ceil.php
@@ -28,9 +28,9 @@ final class Ceil implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/Ceil.php
+++ b/src/Algebra/Ceil.php
@@ -22,15 +22,9 @@ final class Ceil implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return \ceil($this->number->value());
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of(\ceil($this->number->raw()->value()));
     }
 
     #[\Override]
@@ -42,7 +36,7 @@ final class Ceil implements Implementation
     #[\Override]
     public function toString(): string
     {
-        return \var_export($this->value(), true);
+        return \var_export($this->raw()->value(), true);
     }
 
     #[\Override]

--- a/src/Algebra/Ceil.php
+++ b/src/Algebra/Ceil.php
@@ -24,7 +24,7 @@ final class Ceil implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->compute($this->number);
+        return \ceil($this->number->value());
     }
 
     #[\Override]
@@ -49,10 +49,5 @@ final class Ceil implements Implementation
     public function format(): string
     {
         return $this->toString();
-    }
-
-    private function compute(Implementation $number): int|float
-    {
-        return \ceil($number->value());
     }
 }

--- a/src/Algebra/DisplayAs.php
+++ b/src/Algebra/DisplayAs.php
@@ -24,15 +24,9 @@ final class DisplayAs implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return $this->number->value();
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return $this->number->raw();
     }
 
     #[\Override]

--- a/src/Algebra/DisplayAs.php
+++ b/src/Algebra/DisplayAs.php
@@ -24,9 +24,9 @@ final class DisplayAs implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
-        return $this->number->raw();
+        return $this->number->memoize();
     }
 
     #[\Override]

--- a/src/Algebra/DisplayAs.php
+++ b/src/Algebra/DisplayAs.php
@@ -24,7 +24,7 @@ final class DisplayAs implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return $this->number->raw();
     }

--- a/src/Algebra/DisplayAs.php
+++ b/src/Algebra/DisplayAs.php
@@ -30,9 +30,9 @@ final class DisplayAs implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->number->equals($number);
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -16,7 +16,7 @@ final class Division implements Implementation
 
     private function __construct(Implementation $dividend, Implementation $divisor)
     {
-        if ($divisor->optimize()->equals(Value::zero)) {
+        if ($divisor->optimize()->raw()->equals(Value::zero)) {
             throw new DivisionByZero;
         }
 
@@ -49,12 +49,12 @@ final class Division implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return $this->quotient();
     }
 
-    public function quotient(): Implementation
+    public function quotient(): Native|Value
     {
         return Native::of(
             $this->dividend->value() / $this->divisor->value(),

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -43,12 +43,6 @@ final class Division implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return $this->quotient()->value();
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
         return $this->quotient();
@@ -57,7 +51,7 @@ final class Division implements Implementation
     public function quotient(): Native|Value
     {
         return Native::of(
-            $this->dividend->value() / $this->divisor->value(),
+            $this->dividend->raw()->value() / $this->divisor->raw()->value(),
         );
     }
 

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -16,7 +16,7 @@ final class Division implements Implementation
 
     private function __construct(Implementation $dividend, Implementation $divisor)
     {
-        if ($divisor->optimize()->raw()->equals(Native::of(Value::zero))) {
+        if ($divisor->optimize()->memoize()->equals(Native::of(Value::zero))) {
             throw new DivisionByZero;
         }
 
@@ -43,7 +43,7 @@ final class Division implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
         return $this->quotient();
     }
@@ -51,7 +51,7 @@ final class Division implements Implementation
     public function quotient(): Native
     {
         return Native::of(
-            $this->dividend->raw()->value() / $this->divisor->raw()->value(),
+            $this->dividend->memoize()->value() / $this->divisor->memoize()->value(),
         );
     }
 

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -58,9 +58,16 @@ final class Division implements Implementation
     #[\Override]
     public function optimize(): Implementation
     {
+        $dividend = $this->dividend->optimize();
+        $divisor = $this->divisor->optimize();
+
+        if ($divisor->raw()->is(Value::one)) {
+            return $dividend;
+        }
+
         return new self(
-            $this->dividend->optimize(),
-            $this->divisor->optimize(),
+            $dividend,
+            $divisor,
         );
     }
 

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -56,9 +56,8 @@ final class Division implements Implementation
 
     public function quotient(): Implementation
     {
-        return $this->compute(
-            $this->dividend,
-            $this->divisor,
+        return Native::of(
+            $this->dividend->value() / $this->divisor->value(),
         );
     }
 
@@ -88,14 +87,5 @@ final class Division implements Implementation
     public function format(): string
     {
         return '('.$this->toString().')';
-    }
-
-    private function compute(
-        Implementation $dividend,
-        Implementation $divisor,
-    ): Implementation {
-        return Native::of(
-            $dividend->value() / $divisor->value(),
-        );
     }
 }

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -61,7 +61,7 @@ final class Division implements Implementation
         $dividend = $this->dividend->optimize();
         $divisor = $this->divisor->optimize();
 
-        if ($divisor->raw()->is(Value::one)) {
+        if (Value::one->is($divisor)) {
             return $dividend;
         }
 

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -16,7 +16,7 @@ final class Division implements Implementation
 
     private function __construct(Implementation $dividend, Implementation $divisor)
     {
-        if ($divisor->optimize()->value() == 0) {
+        if ($divisor->optimize()->equals(Value::zero)) {
             throw new DivisionByZero;
         }
 

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -16,7 +16,7 @@ final class Division implements Implementation
 
     private function __construct(Implementation $dividend, Implementation $divisor)
     {
-        if ($divisor->optimize()->raw()->equals(Value::zero)) {
+        if ($divisor->optimize()->raw()->equals(Native::of(Value::zero))) {
             throw new DivisionByZero;
         }
 
@@ -43,12 +43,12 @@ final class Division implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return $this->quotient();
     }
 
-    public function quotient(): Native|Value
+    public function quotient(): Native
     {
         return Native::of(
             $this->dividend->raw()->value() / $this->divisor->raw()->value(),

--- a/src/Algebra/Division.php
+++ b/src/Algebra/Division.php
@@ -16,7 +16,7 @@ final class Division implements Implementation
 
     private function __construct(Implementation $dividend, Implementation $divisor)
     {
-        if ($divisor->optimize()->memoize()->equals(Native::of(Value::zero))) {
+        if ($divisor->optimize()->memoize()->is(Value::zero)) {
             throw new DivisionByZero;
         }
 

--- a/src/Algebra/Exponential.php
+++ b/src/Algebra/Exponential.php
@@ -22,7 +22,7 @@ final class Exponential implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of(\exp($this->power->raw()->value()));
     }

--- a/src/Algebra/Exponential.php
+++ b/src/Algebra/Exponential.php
@@ -28,9 +28,9 @@ final class Exponential implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/Exponential.php
+++ b/src/Algebra/Exponential.php
@@ -22,15 +22,9 @@ final class Exponential implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return \exp($this->power->value());
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of(\exp($this->power->raw()->value()));
     }
 
     #[\Override]

--- a/src/Algebra/Exponential.php
+++ b/src/Algebra/Exponential.php
@@ -24,7 +24,7 @@ final class Exponential implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->result()->value();
+        return \exp($this->power->value());
     }
 
     #[\Override]
@@ -51,17 +51,5 @@ final class Exponential implements Implementation
     public function format(): string
     {
         return '('.$this->toString().')';
-    }
-
-    private function result(): Implementation
-    {
-        return $this->compute($this->power);
-    }
-
-    private function compute(Implementation $power): Implementation
-    {
-        return Native::of(
-            \exp($power->value()),
-        );
     }
 }

--- a/src/Algebra/Exponential.php
+++ b/src/Algebra/Exponential.php
@@ -22,9 +22,9 @@ final class Exponential implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
-        return Native::of(\exp($this->power->raw()->value()));
+        return Native::of(\exp($this->power->memoize()->value()));
     }
 
     #[\Override]

--- a/src/Algebra/Factorial.php
+++ b/src/Algebra/Factorial.php
@@ -3,27 +3,23 @@ declare(strict_types = 1);
 
 namespace Innmind\Math\Algebra;
 
-use Innmind\Math\Exception\FactorialMustBePositive;
-
 /**
  * @psalm-immutable
  * @internal
  */
 final class Factorial
 {
-    private int $value;
-
-    private function __construct(int $value)
+    /**
+     * @param int<0, max> $value
+     */
+    private function __construct(private int $value)
     {
-        if ($value < 0) {
-            throw new FactorialMustBePositive((string) $value);
-        }
-
-        $this->value = $value;
     }
 
     /**
      * @psalm-pure
+     *
+     * @param int<0, max> $value
      */
     public static function of(int $value): self
     {

--- a/src/Algebra/Floor.php
+++ b/src/Algebra/Floor.php
@@ -22,9 +22,9 @@ final class Floor implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
-        return Native::of(\floor($this->number->raw()->value()));
+        return Native::of(\floor($this->number->memoize()->value()));
     }
 
     #[\Override]
@@ -36,7 +36,7 @@ final class Floor implements Implementation
     #[\Override]
     public function toString(): string
     {
-        return \var_export($this->raw()->value(), true);
+        return \var_export($this->memoize()->value(), true);
     }
 
     #[\Override]

--- a/src/Algebra/Floor.php
+++ b/src/Algebra/Floor.php
@@ -22,15 +22,9 @@ final class Floor implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return \floor($this->number->value());
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of(\floor($this->number->raw()->value()));
     }
 
     #[\Override]
@@ -42,7 +36,7 @@ final class Floor implements Implementation
     #[\Override]
     public function toString(): string
     {
-        return \var_export($this->value(), true);
+        return \var_export($this->raw()->value(), true);
     }
 
     #[\Override]

--- a/src/Algebra/Floor.php
+++ b/src/Algebra/Floor.php
@@ -28,9 +28,9 @@ final class Floor implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/Floor.php
+++ b/src/Algebra/Floor.php
@@ -22,7 +22,7 @@ final class Floor implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of(\floor($this->number->raw()->value()));
     }

--- a/src/Algebra/Floor.php
+++ b/src/Algebra/Floor.php
@@ -24,7 +24,7 @@ final class Floor implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->compute($this->number);
+        return \floor($this->number->value());
     }
 
     #[\Override]
@@ -49,10 +49,5 @@ final class Floor implements Implementation
     public function format(): string
     {
         return $this->toString();
-    }
-
-    private function compute(Implementation $number): int|float
-    {
-        return \floor($number->value());
     }
 }

--- a/src/Algebra/Implementation.php
+++ b/src/Algebra/Implementation.php
@@ -9,7 +9,7 @@ namespace Innmind\Math\Algebra;
  */
 interface Implementation
 {
-    public function raw(): Native|Value;
+    public function raw(): Native;
     public function toString(): string;
     public function format(): string;
     public function optimize(): self;

--- a/src/Algebra/Implementation.php
+++ b/src/Algebra/Implementation.php
@@ -10,7 +10,7 @@ namespace Innmind\Math\Algebra;
 interface Implementation
 {
     public function value(): int|float;
-    public function equals(self $number): bool;
+    public function raw(): Native|Value;
     public function toString(): string;
     public function format(): string;
     public function optimize(): self;

--- a/src/Algebra/Implementation.php
+++ b/src/Algebra/Implementation.php
@@ -9,7 +9,6 @@ namespace Innmind\Math\Algebra;
  */
 interface Implementation
 {
-    public function value(): int|float;
     public function raw(): Native|Value;
     public function toString(): string;
     public function format(): string;

--- a/src/Algebra/Implementation.php
+++ b/src/Algebra/Implementation.php
@@ -9,7 +9,7 @@ namespace Innmind\Math\Algebra;
  */
 interface Implementation
 {
-    public function raw(): Native;
+    public function memoize(): Native;
     public function toString(): string;
     public function format(): string;
     public function optimize(): self;

--- a/src/Algebra/Modulo.php
+++ b/src/Algebra/Modulo.php
@@ -24,7 +24,7 @@ final class Modulo implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of(\fmod(
             $this->number->raw()->value(),

--- a/src/Algebra/Modulo.php
+++ b/src/Algebra/Modulo.php
@@ -33,9 +33,9 @@ final class Modulo implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/Modulo.php
+++ b/src/Algebra/Modulo.php
@@ -24,18 +24,12 @@ final class Modulo implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        // wrap to throw in case of invlid values
-        return Native::of(
-            \fmod($this->number->value(), $this->modulus->value()),
-        )->value();
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of(\fmod(
+            $this->number->raw()->value(),
+            $this->modulus->raw()->value(),
+        ));
     }
 
     #[\Override]

--- a/src/Algebra/Modulo.php
+++ b/src/Algebra/Modulo.php
@@ -26,7 +26,10 @@ final class Modulo implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->result()->value();
+        // wrap to throw in case of invlid values
+        return Native::of(
+            \fmod($this->number->value(), $this->modulus->value()),
+        )->value();
     }
 
     #[\Override]
@@ -57,19 +60,5 @@ final class Modulo implements Implementation
     public function format(): string
     {
         return '('.$this->toString().')';
-    }
-
-    private function result(): Implementation
-    {
-        return $this->compute($this->number, $this->modulus);
-    }
-
-    private function compute(
-        Implementation $number,
-        Implementation $modulus,
-    ): Implementation {
-        return Native::of(
-            \fmod($number->value(), $modulus->value()),
-        );
     }
 }

--- a/src/Algebra/Modulo.php
+++ b/src/Algebra/Modulo.php
@@ -24,11 +24,11 @@ final class Modulo implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
         return Native::of(\fmod(
-            $this->number->raw()->value(),
-            $this->modulus->raw()->value(),
+            $this->number->memoize()->value(),
+            $this->modulus->memoize()->value(),
         ));
     }
 

--- a/src/Algebra/Multiplication.php
+++ b/src/Algebra/Multiplication.php
@@ -29,12 +29,12 @@ final class Multiplication implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return $this->product();
     }
 
-    public function product(): Native|Value
+    public function product(): Native
     {
         return Native::of($this->a->raw()->value() * $this->b->raw()->value());
     }

--- a/src/Algebra/Multiplication.php
+++ b/src/Algebra/Multiplication.php
@@ -29,14 +29,14 @@ final class Multiplication implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
         return $this->product();
     }
 
     public function product(): Native
     {
-        return Native::of($this->a->raw()->value() * $this->b->raw()->value());
+        return Native::of($this->a->memoize()->value() * $this->b->memoize()->value());
     }
 
     #[\Override]
@@ -49,7 +49,7 @@ final class Multiplication implements Implementation
         if ($a instanceof Division) {
             $divisor = $a->divisor();
 
-            if ($b->raw()->equals($divisor->raw())) {
+            if ($b->memoize()->equals($divisor->memoize())) {
                 return $a->dividend();
             }
         }
@@ -58,7 +58,7 @@ final class Multiplication implements Implementation
         if ($b instanceof Division) {
             $divisor = $b->divisor();
 
-            if ($a->raw()->equals($divisor->raw())) {
+            if ($a->memoize()->equals($divisor->memoize())) {
                 return $b->dividend();
             }
         }

--- a/src/Algebra/Multiplication.php
+++ b/src/Algebra/Multiplication.php
@@ -35,12 +35,12 @@ final class Multiplication implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return $this->product();
     }
 
-    public function product(): Implementation
+    public function product(): Native|Value
     {
         return Native::of($this->a->value() * $this->b->value());
     }
@@ -54,7 +54,7 @@ final class Multiplication implements Implementation
         if ($a instanceof Division) {
             $divisor = $a->divisor();
 
-            if ($b->equals($divisor)) {
+            if ($b->raw()->equals($divisor->raw())) {
                 return $a->dividend();
             }
         }
@@ -62,7 +62,7 @@ final class Multiplication implements Implementation
         if ($b instanceof Division) {
             $divisor = $b->divisor();
 
-            if ($a->equals($divisor)) {
+            if ($a->raw()->equals($divisor->raw())) {
                 return $b->dividend();
             }
         }

--- a/src/Algebra/Multiplication.php
+++ b/src/Algebra/Multiplication.php
@@ -63,7 +63,7 @@ final class Multiplication implements Implementation
             }
         }
 
-        return $this;
+        return new self($a, $b);
     }
 
     #[\Override]

--- a/src/Algebra/Multiplication.php
+++ b/src/Algebra/Multiplication.php
@@ -45,6 +45,7 @@ final class Multiplication implements Implementation
         $a = $this->a->optimize();
         $b = $this->b->optimize();
 
+        // (dividend/divisor)*b = dividend
         if ($a instanceof Division) {
             $divisor = $a->divisor();
 
@@ -53,6 +54,7 @@ final class Multiplication implements Implementation
             }
         }
 
+        // a*(dividend/divisor) = dividend
         if ($b instanceof Division) {
             $divisor = $b->divisor();
 

--- a/src/Algebra/Multiplication.php
+++ b/src/Algebra/Multiplication.php
@@ -29,12 +29,6 @@ final class Multiplication implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return $this->product()->value();
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
         return $this->product();
@@ -42,7 +36,7 @@ final class Multiplication implements Implementation
 
     public function product(): Native|Value
     {
-        return Native::of($this->a->value() * $this->b->value());
+        return Native::of($this->a->raw()->value() * $this->b->raw()->value());
     }
 
     #[\Override]

--- a/src/Algebra/Native.php
+++ b/src/Algebra/Native.php
@@ -18,7 +18,7 @@ final class Native implements Implementation
     /**
      * @psalm-pure
      */
-    public static function of(int|float $value): Implementation
+    public static function of(int|float $value): self|Value
     {
         if (\is_infinite($value)) {
             return $value > 0 ? Value::infinite : Value::negativeInfinite;
@@ -47,7 +47,12 @@ final class Native implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): self
+    {
+        return $this;
+    }
+
+    public function equals(self|Value $number): bool
     {
         return $this->value == $number->value();
     }

--- a/src/Algebra/Native.php
+++ b/src/Algebra/Native.php
@@ -54,7 +54,7 @@ final class Native implements Implementation
     }
 
     #[\Override]
-    public function raw(): self
+    public function memoize(): self
     {
         return $this;
     }

--- a/src/Algebra/Native.php
+++ b/src/Algebra/Native.php
@@ -59,6 +59,11 @@ final class Native implements Implementation
         return $this;
     }
 
+    public function is(Value $value): bool
+    {
+        return $this->value === $value;
+    }
+
     public function equals(self $number): bool
     {
         if ($this->value instanceof Value && $number->value instanceof Value) {

--- a/src/Algebra/Native.php
+++ b/src/Algebra/Native.php
@@ -33,11 +33,11 @@ final class Native implements Implementation
         }
 
         return new self(match ($value) {
-            0 => Value::zero,
-            1 => Value::one,
-            2 => Value::two,
-            10 => Value::ten,
-            100 => Value::hundred,
+            0, 0.0 => Value::zero,
+            1, 1.0 => Value::one,
+            2, 2.0 => Value::two,
+            10, 10.0 => Value::ten,
+            100, 100.0 => Value::hundred,
             \M_E => Value::e,
             \M_PI => Value::pi,
             default => $value,

--- a/src/Algebra/Native.php
+++ b/src/Algebra/Native.php
@@ -40,7 +40,6 @@ final class Native implements Implementation
         };
     }
 
-    #[\Override]
     public function value(): int|float
     {
         return $this->value;

--- a/src/Algebra/Number.php
+++ b/src/Algebra/Number.php
@@ -28,7 +28,7 @@ final class Number
     #[\NoDiscard]
     public static function zero(): self
     {
-        return new self(Value::zero);
+        return new self(Native::of(Value::zero));
     }
 
     /**
@@ -37,7 +37,7 @@ final class Number
     #[\NoDiscard]
     public static function one(): self
     {
-        return new self(Value::one);
+        return new self(Native::of(Value::one));
     }
 
     /**
@@ -46,7 +46,7 @@ final class Number
     #[\NoDiscard]
     public static function two(): self
     {
-        return new self(Value::two);
+        return new self(Native::of(Value::two));
     }
 
     /**
@@ -55,7 +55,7 @@ final class Number
     #[\NoDiscard]
     public static function ten(): self
     {
-        return new self(Value::ten);
+        return new self(Native::of(Value::ten));
     }
 
     /**
@@ -64,7 +64,7 @@ final class Number
     #[\NoDiscard]
     public static function hundred(): self
     {
-        return new self(Value::hundred);
+        return new self(Native::of(Value::hundred));
     }
 
     /**
@@ -73,7 +73,7 @@ final class Number
     #[\NoDiscard]
     public static function e(): self
     {
-        return new self(Value::e);
+        return new self(Native::of(Value::e));
     }
 
     /**
@@ -82,7 +82,7 @@ final class Number
     #[\NoDiscard]
     public static function pi(): self
     {
-        return new self(Value::pi);
+        return new self(Native::of(Value::pi));
     }
 
     /**
@@ -91,7 +91,7 @@ final class Number
     #[\NoDiscard]
     public static function infinite(): self
     {
-        return new self(Value::infinite);
+        return new self(Native::of(Value::infinite));
     }
 
     /**
@@ -100,7 +100,7 @@ final class Number
     #[\NoDiscard]
     public static function negativeInfinite(): self
     {
-        return new self(Value::negativeInfinite);
+        return new self(Native::of(Value::negativeInfinite));
     }
 
     #[\NoDiscard]

--- a/src/Algebra/Number.php
+++ b/src/Algebra/Number.php
@@ -112,14 +112,14 @@ final class Number
     #[\NoDiscard]
     public function value(): int|float
     {
-        return $this->implementation->raw()->value();
+        return $this->implementation->memoize()->value();
     }
 
     #[\NoDiscard]
     public function equals(self $number): bool
     {
-        return $this->implementation->raw()->equals(
-            $number->implementation->raw(),
+        return $this->implementation->memoize()->equals(
+            $number->implementation->memoize(),
         );
     }
 
@@ -317,10 +317,6 @@ final class Number
     #[\NoDiscard]
     public function memoize(): self
     {
-        if ($this->implementation instanceof Native) {
-            return $this;
-        }
-
-        return self::of($this->value());
+        return new self($this->implementation->memoize());
     }
 }

--- a/src/Algebra/Number.php
+++ b/src/Algebra/Number.php
@@ -112,7 +112,7 @@ final class Number
     #[\NoDiscard]
     public function value(): int|float
     {
-        return $this->implementation->value();
+        return $this->implementation->raw()->value();
     }
 
     #[\NoDiscard]

--- a/src/Algebra/Number.php
+++ b/src/Algebra/Number.php
@@ -118,8 +118,8 @@ final class Number
     #[\NoDiscard]
     public function equals(self $number): bool
     {
-        return $this->implementation->equals(
-            $number->implementation,
+        return $this->implementation->raw()->equals(
+            $number->implementation->raw(),
         );
     }
 

--- a/src/Algebra/Power.php
+++ b/src/Algebra/Power.php
@@ -26,7 +26,7 @@ final class Power implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->result()->value();
+        return $this->number->value() ** $this->power->value();
     }
 
     #[\Override]
@@ -68,12 +68,5 @@ final class Power implements Implementation
     public function format(): string
     {
         return '('.$this->toString().')';
-    }
-
-    private function result(): Implementation
-    {
-        return Native::of(
-            $this->number->value() ** $this->power->value(),
-        );
     }
 }

--- a/src/Algebra/Power.php
+++ b/src/Algebra/Power.php
@@ -24,15 +24,9 @@ final class Power implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return $this->number->value() ** $this->power->value();
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of($this->number->raw()->value() ** $this->power->raw()->value());
     }
 
     #[\Override]

--- a/src/Algebra/Power.php
+++ b/src/Algebra/Power.php
@@ -30,9 +30,9 @@ final class Power implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]
@@ -52,7 +52,7 @@ final class Power implements Implementation
 
     public function square(): bool
     {
-        return $this->power->equals(Value::two);
+        return $this->power->raw()->equals(Value::two);
     }
 
     #[\Override]

--- a/src/Algebra/Power.php
+++ b/src/Algebra/Power.php
@@ -32,11 +32,17 @@ final class Power implements Implementation
     #[\Override]
     public function optimize(): Implementation
     {
-        if ($this->number instanceof SquareRoot && $this->square()) {
-            return $this->number->number()->optimize();
+        $number = $this->number->optimize();
+        $power = $this->power->optimize();
+
+        if ($number instanceof SquareRoot && $power->raw()->is(Value::two)) {
+            return $number->number()->optimize();
         }
 
-        return $this;
+        return new self(
+            $number,
+            $power,
+        );
     }
 
     public function number(): Implementation
@@ -46,7 +52,7 @@ final class Power implements Implementation
 
     public function square(): bool
     {
-        return $this->power->raw()->equals(Native::of(Value::two));
+        return $this->power->optimize()->raw()->is(Value::two);
     }
 
     #[\Override]

--- a/src/Algebra/Power.php
+++ b/src/Algebra/Power.php
@@ -24,9 +24,9 @@ final class Power implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
-        return Native::of($this->number->raw()->value() ** $this->power->raw()->value());
+        return Native::of($this->number->memoize()->value() ** $this->power->memoize()->value());
     }
 
     #[\Override]

--- a/src/Algebra/Power.php
+++ b/src/Algebra/Power.php
@@ -35,7 +35,7 @@ final class Power implements Implementation
         $number = $this->number->optimize();
         $power = $this->power->optimize();
 
-        if ($number instanceof SquareRoot && $power->raw()->is(Value::two)) {
+        if ($number instanceof SquareRoot && Value::two->is($power)) {
             return $number->number()->optimize();
         }
 
@@ -52,7 +52,7 @@ final class Power implements Implementation
 
     public function square(): bool
     {
-        return $this->power->optimize()->raw()->is(Value::two);
+        return Value::two->is($this->power->optimize());
     }
 
     #[\Override]

--- a/src/Algebra/Power.php
+++ b/src/Algebra/Power.php
@@ -24,7 +24,7 @@ final class Power implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of($this->number->raw()->value() ** $this->power->raw()->value());
     }
@@ -46,7 +46,7 @@ final class Power implements Implementation
 
     public function square(): bool
     {
-        return $this->power->raw()->equals(Value::two);
+        return $this->power->raw()->equals(Native::of(Value::two));
     }
 
     #[\Override]

--- a/src/Algebra/Round.php
+++ b/src/Algebra/Round.php
@@ -71,9 +71,9 @@ final class Round implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/Round.php
+++ b/src/Algebra/Round.php
@@ -61,19 +61,13 @@ final class Round implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return \round(
-            $this->number->value(),
-            $this->precision,
-            $this->mode,
-        );
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of(\round(
+            $this->number->raw()->value(),
+            $this->precision,
+            $this->mode,
+        ));
     }
 
     #[\Override]
@@ -89,7 +83,7 @@ final class Round implements Implementation
     #[\Override]
     public function toString(): string
     {
-        return \var_export($this->value(), true);
+        return \var_export($this->raw()->value(), true);
     }
 
     #[\Override]

--- a/src/Algebra/Round.php
+++ b/src/Algebra/Round.php
@@ -61,7 +61,7 @@ final class Round implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of(\round(
             $this->number->raw()->value(),

--- a/src/Algebra/Round.php
+++ b/src/Algebra/Round.php
@@ -61,10 +61,10 @@ final class Round implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
         return Native::of(\round(
-            $this->number->raw()->value(),
+            $this->number->memoize()->value(),
             $this->precision,
             $this->mode,
         ));
@@ -83,7 +83,7 @@ final class Round implements Implementation
     #[\Override]
     public function toString(): string
     {
-        return \var_export($this->raw()->value(), true);
+        return \var_export($this->memoize()->value(), true);
     }
 
     #[\Override]

--- a/src/Algebra/Round.php
+++ b/src/Algebra/Round.php
@@ -63,7 +63,11 @@ final class Round implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->compute($this->number);
+        return \round(
+            $this->number->value(),
+            $this->precision,
+            $this->mode,
+        );
     }
 
     #[\Override]
@@ -92,14 +96,5 @@ final class Round implements Implementation
     public function format(): string
     {
         return $this->toString();
-    }
-
-    private function compute(Implementation $number): int|float
-    {
-        return \round(
-            $number->value(),
-            $this->precision,
-            $this->mode,
-        );
     }
 }

--- a/src/Algebra/Signum.php
+++ b/src/Algebra/Signum.php
@@ -24,7 +24,7 @@ final class Signum implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->result()->value();
+        return $this->number->value() <=> 0;
     }
 
     #[\Override]
@@ -49,17 +49,5 @@ final class Signum implements Implementation
     public function format(): string
     {
         return $this->toString();
-    }
-
-    private function result(): Implementation
-    {
-        return $this->compute($this->number);
-    }
-
-    private function compute(Implementation $number): Implementation
-    {
-        return Native::of(
-            $number->value() <=> 0,
-        );
     }
 }

--- a/src/Algebra/Signum.php
+++ b/src/Algebra/Signum.php
@@ -22,9 +22,9 @@ final class Signum implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
-        return Native::of($this->number->raw()->value() <=> 0);
+        return Native::of($this->number->memoize()->value() <=> 0);
     }
 
     #[\Override]

--- a/src/Algebra/Signum.php
+++ b/src/Algebra/Signum.php
@@ -22,7 +22,7 @@ final class Signum implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of($this->number->raw()->value() <=> 0);
     }

--- a/src/Algebra/Signum.php
+++ b/src/Algebra/Signum.php
@@ -28,9 +28,9 @@ final class Signum implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/Signum.php
+++ b/src/Algebra/Signum.php
@@ -22,15 +22,9 @@ final class Signum implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return $this->number->value() <=> 0;
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of($this->number->raw()->value() <=> 0);
     }
 
     #[\Override]

--- a/src/Algebra/SquareRoot.php
+++ b/src/Algebra/SquareRoot.php
@@ -30,11 +30,13 @@ final class SquareRoot implements Implementation
     #[\Override]
     public function optimize(): Implementation
     {
-        if ($this->number instanceof Power && $this->number->square()) {
-            return $this->number->number()->optimize();
+        $number = $this->number->optimize();
+
+        if ($number instanceof Power && $number->square()) {
+            return $number->number()->optimize();
         }
 
-        return $this;
+        return new self($number);
     }
 
     public function number(): Implementation

--- a/src/Algebra/SquareRoot.php
+++ b/src/Algebra/SquareRoot.php
@@ -24,7 +24,7 @@ final class SquareRoot implements Implementation
     #[\Override]
     public function value(): int|float
     {
-        return $this->result()->value();
+        return \sqrt($this->number->value());
     }
 
     #[\Override]
@@ -60,12 +60,5 @@ final class SquareRoot implements Implementation
     public function format(): string
     {
         return '('.$this->toString().')';
-    }
-
-    private function result(): Implementation
-    {
-        return Native::of(
-            \sqrt($this->number->value()),
-        );
     }
 }

--- a/src/Algebra/SquareRoot.php
+++ b/src/Algebra/SquareRoot.php
@@ -22,15 +22,9 @@ final class SquareRoot implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return \sqrt($this->number->value());
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
-        return Native::of($this->value());
+        return Native::of(\sqrt($this->number->raw()->value()));
     }
 
     #[\Override]

--- a/src/Algebra/SquareRoot.php
+++ b/src/Algebra/SquareRoot.php
@@ -28,9 +28,9 @@ final class SquareRoot implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return Native::of($this->value());
     }
 
     #[\Override]

--- a/src/Algebra/SquareRoot.php
+++ b/src/Algebra/SquareRoot.php
@@ -22,7 +22,7 @@ final class SquareRoot implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return Native::of(\sqrt($this->number->raw()->value()));
     }

--- a/src/Algebra/SquareRoot.php
+++ b/src/Algebra/SquareRoot.php
@@ -22,9 +22,9 @@ final class SquareRoot implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
-        return Native::of(\sqrt($this->number->raw()->value()));
+        return Native::of(\sqrt($this->number->memoize()->value()));
     }
 
     #[\Override]

--- a/src/Algebra/Subtraction.php
+++ b/src/Algebra/Subtraction.php
@@ -29,14 +29,14 @@ final class Subtraction implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native
+    public function memoize(): Native
     {
         return $this->difference();
     }
 
     public function difference(): Native
     {
-        return Native::of($this->a->raw()->value() - $this->b->raw()->value());
+        return Native::of($this->a->memoize()->value() - $this->b->memoize()->value());
     }
 
     #[\Override]

--- a/src/Algebra/Subtraction.php
+++ b/src/Algebra/Subtraction.php
@@ -35,12 +35,12 @@ final class Subtraction implements Implementation
     }
 
     #[\Override]
-    public function equals(Implementation $number): bool
+    public function raw(): Native|Value
     {
-        return $this->value() == $number->value();
+        return $this->difference();
     }
 
-    public function difference(): Implementation
+    public function difference(): Native|Value
     {
         return Native::of($this->a->value() - $this->b->value());
     }

--- a/src/Algebra/Subtraction.php
+++ b/src/Algebra/Subtraction.php
@@ -29,12 +29,12 @@ final class Subtraction implements Implementation
     }
 
     #[\Override]
-    public function raw(): Native|Value
+    public function raw(): Native
     {
         return $this->difference();
     }
 
-    public function difference(): Native|Value
+    public function difference(): Native
     {
         return Native::of($this->a->raw()->value() - $this->b->raw()->value());
     }

--- a/src/Algebra/Subtraction.php
+++ b/src/Algebra/Subtraction.php
@@ -29,12 +29,6 @@ final class Subtraction implements Implementation
     }
 
     #[\Override]
-    public function value(): int|float
-    {
-        return $this->difference()->value();
-    }
-
-    #[\Override]
     public function raw(): Native|Value
     {
         return $this->difference();
@@ -42,7 +36,7 @@ final class Subtraction implements Implementation
 
     public function difference(): Native|Value
     {
-        return Native::of($this->a->value() - $this->b->value());
+        return Native::of($this->a->raw()->value() - $this->b->raw()->value());
     }
 
     #[\Override]

--- a/src/Algebra/Value.php
+++ b/src/Algebra/Value.php
@@ -20,6 +20,24 @@ enum Value
     case infinite;
     case negativeInfinite;
 
+    /**
+     * This allows to safely check if numbers are this integer without computing
+     * the real value.
+     */
+    public function is(Implementation $number): bool
+    {
+        if ($number instanceof Native) {
+            return $number->is($this);
+        }
+
+        // todo allow to optimize on addition, multiplication and subtraction ?
+        // this could be checked if each component is an int but the
+        // recursiveness can be expansive to walk through
+
+        // other than zero through hundred we prevent optimizing
+        return false;
+    }
+
     public function value(): int|float
     {
         return match ($this) {

--- a/src/Algebra/Value.php
+++ b/src/Algebra/Value.php
@@ -7,7 +7,7 @@ namespace Innmind\Math\Algebra;
  * @psalm-immutable
  * @internal
  */
-enum Value implements Implementation
+enum Value
 {
     case zero;
     case one;
@@ -35,28 +35,6 @@ enum Value implements Implementation
         };
     }
 
-    public function equals(Native|self $number): bool
-    {
-        if ($number instanceof self) {
-            return $this === $number;
-        }
-
-        return $number->equals($this);
-    }
-
-    #[\Override]
-    public function raw(): Native|Value
-    {
-        return $this;
-    }
-
-    #[\Override]
-    public function optimize(): Implementation
-    {
-        return $this;
-    }
-
-    #[\Override]
     public function toString(): string
     {
         return match ($this) {
@@ -70,11 +48,5 @@ enum Value implements Implementation
             self::infinite => '+∞',
             self::negativeInfinite => '-∞',
         };
-    }
-
-    #[\Override]
-    public function format(): string
-    {
-        return $this->toString();
     }
 }

--- a/src/Algebra/Value.php
+++ b/src/Algebra/Value.php
@@ -36,10 +36,19 @@ enum Value implements Implementation
         };
     }
 
-    #[\Override]
-    public function equals(Implementation $number): bool
+    public function equals(Native|self $number): bool
     {
-        return $this->value() == $number->value();
+        if ($number instanceof self) {
+            return $this === $number;
+        }
+
+        return $number->equals($this);
+    }
+
+    #[\Override]
+    public function raw(): Native|Value
+    {
+        return $this;
     }
 
     #[\Override]

--- a/src/Algebra/Value.php
+++ b/src/Algebra/Value.php
@@ -20,7 +20,6 @@ enum Value implements Implementation
     case infinite;
     case negativeInfinite;
 
-    #[\Override]
     public function value(): int|float
     {
         return match ($this) {

--- a/src/DefinitionSet/Values.php
+++ b/src/DefinitionSet/Values.php
@@ -42,7 +42,7 @@ final class Values implements Implementation
     #[\Override]
     public function toString(): string
     {
-        if ($this->values->size() === 0) {
+        if ($this->values->empty()) {
             return '∅';
         }
 

--- a/src/Exception/FactorialMustBePositive.php
+++ b/src/Exception/FactorialMustBePositive.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Math\Exception;
-
-final class FactorialMustBePositive extends LogicException
-{
-}

--- a/src/Polynom/Degree.php
+++ b/src/Polynom/Degree.php
@@ -40,6 +40,15 @@ final class Degree
     }
 
     /**
+     * @param int<1, max> $degree
+     */
+    #[\NoDiscard]
+    public function is(int $degree): bool
+    {
+        return $this->degree === $degree;
+    }
+
+    /**
      * @return int<1, max>
      */
     #[\NoDiscard]
@@ -81,7 +90,7 @@ final class Degree
     {
         $coeff = $this->coeff->format();
 
-        if ($this->degree === 1) {
+        if ($this->is(1)) {
             return $coeff.'x';
         }
 

--- a/src/Polynom/Polynom.php
+++ b/src/Polynom/Polynom.php
@@ -76,7 +76,7 @@ final class Polynom
             $this->intercept,
             $this
                 ->degrees
-                ->exclude(static fn($known) => $known->degree() === $degree)
+                ->exclude(static fn($known) => $known->is($degree))
                 ->add(Degree::of($degree, $coeff)),
         );
     }
@@ -101,7 +101,7 @@ final class Polynom
     public function degree(int $degree): Maybe
     {
         return $this->degrees->find(
-            static fn($known) => $known->degree() === $degree,
+            static fn($known) => $known->is($degree),
         );
     }
 
@@ -154,12 +154,12 @@ final class Polynom
     {
         [$intercept, $degrees] = $this
             ->degrees
-            ->find(static fn($degree) => $degree->degree() === 1)
+            ->find(static fn($degree) => $degree->is(1))
             ->match(
                 fn($degree) => [
                     $degree->coeff(),
                     $this->degrees->exclude(
-                        static fn($degree) => $degree->degree() === 1,
+                        static fn($degree) => $degree->is(1),
                     ),
                 ],
                 fn() => [Number::zero(), $this->degrees],

--- a/src/Probabilities/BinomialDistribution.php
+++ b/src/Probabilities/BinomialDistribution.php
@@ -17,10 +17,19 @@ final class BinomialDistribution
     {
     }
 
+    /**
+     * @param int<0, max> $trials
+     * @param int<0, max> $success
+     */
     #[\NoDiscard]
     public function __invoke(int $trials, int $success): Number
     {
         $errors = $trials - $success;
+
+        if ($errors < 0) {
+            throw new \LogicException('There must be more trials than successes');
+        }
+
         $coefficient = Factorial::of($trials)
             ->number()
             ->divideBy(

--- a/tests/Algebra/AbsoluteTest.php
+++ b/tests/Algebra/AbsoluteTest.php
@@ -125,7 +125,7 @@ class AbsoluteTest extends TestCase
         $absolute = Number::of(-4)->absolute();
         $number = $absolute->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/AdditionTest.php
+++ b/tests/Algebra/AdditionTest.php
@@ -159,7 +159,7 @@ class AdditionTest extends TestCase
         );
         $number = $addition->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/BinaryLogarithmTest.php
+++ b/tests/Algebra/BinaryLogarithmTest.php
@@ -30,14 +30,14 @@ class BinaryLogarithmTest extends TestCase
     {
         $lb = Number::of(1)->apply(Logarithm::binary);
 
-        $this->assertSame(0.0, $lb->value());
+        $this->assertSame(0, $lb->value());
     }
 
     public function testValue()
     {
         $lb = Number::of(1)->apply(Logarithm::binary);
 
-        $this->assertSame(0.0, $lb->value());
+        $this->assertSame(0, $lb->value());
     }
 
     public function testStringCast()
@@ -69,7 +69,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->add(Number::of(7));
 
-        $this->assertSame(7.0, $number->value());
+        $this->assertSame(7, $number->value());
     }
 
     public function testSubtract()
@@ -77,7 +77,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->subtract(Number::of(7));
 
-        $this->assertSame(-7.0, $number->value());
+        $this->assertSame(-7, $number->value());
     }
 
     public function testMultiplication()
@@ -85,7 +85,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->multiplyBy(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testDivision()
@@ -93,7 +93,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->divideBy(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testFloor()
@@ -101,7 +101,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->floor();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testCeil()
@@ -109,7 +109,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->ceil();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testAbsolute()
@@ -117,7 +117,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(0.5)->apply(Logarithm::binary);
         $number = $lb->absolute();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testModulo()
@@ -125,7 +125,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->modulo(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testPower()
@@ -133,7 +133,7 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->power(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testSquareRoot()
@@ -141,35 +141,35 @@ class BinaryLogarithmTest extends TestCase
         $lb = Number::of(1)->apply(Logarithm::binary);
         $number = $lb->squareRoot();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testExponential()
     {
         $number = Number::of(1)->apply(Logarithm::binary)->exponential();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testBinaryLogarithm()
     {
         $number = Number::of(2)->apply(Logarithm::binary)->apply(Logarithm::base2);
 
-        $this->assertSame(\log(\log(2, 2), 2), $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testNaturalLogarithm()
     {
         $number = Number::of(2)->apply(Logarithm::binary)->apply(Logarithm::baseE);
 
-        $this->assertSame(\log(\log(2, 2)), $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testCommonLogarithm()
     {
         $number = Number::of(2)->apply(Logarithm::binary)->apply(Logarithm::base10);
 
-        $this->assertSame(\log10(\log(2, 2)), $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testSignum()

--- a/tests/Algebra/CeilTest.php
+++ b/tests/Algebra/CeilTest.php
@@ -126,7 +126,7 @@ class CeilTest extends TestCase
         $ceil = Number::of(3.5)->ceil();
         $number = $ceil->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/CommonLogarithmTest.php
+++ b/tests/Algebra/CommonLogarithmTest.php
@@ -30,14 +30,14 @@ class CommonLogarithmTest extends TestCase
     {
         $lg = Number::of(1)->apply(Logarithm::common);
 
-        $this->assertSame(0.0, $lg->value());
+        $this->assertSame(0, $lg->value());
     }
 
     public function testValue()
     {
         $lg = Number::of(1)->apply(Logarithm::common);
 
-        $this->assertSame(0.0, $lg->value());
+        $this->assertSame(0, $lg->value());
     }
 
     public function testStringCast()
@@ -69,7 +69,7 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->add(Number::of(7));
 
-        $this->assertSame(7.0, $number->value());
+        $this->assertSame(7, $number->value());
     }
 
     public function testSubtract()
@@ -77,7 +77,7 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->subtract(Number::of(7));
 
-        $this->assertSame(-7.0, $number->value());
+        $this->assertSame(-7, $number->value());
     }
 
     public function testMultiplication()
@@ -85,7 +85,7 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->multiplyBy(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testDivision()
@@ -93,7 +93,7 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->divideBy(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testFloor()
@@ -101,7 +101,7 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->floor();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testCeil()
@@ -109,7 +109,7 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->ceil();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testAbsolute()
@@ -125,7 +125,7 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->modulo(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testPower()
@@ -133,7 +133,7 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->power(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testSquareRoot()
@@ -141,14 +141,14 @@ class CommonLogarithmTest extends TestCase
         $lg = Number::of(1)->apply(Logarithm::common);
         $number = $lg->squareRoot();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testExponential()
     {
         $number = Number::of(1)->apply(Logarithm::common)->exponential();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testBinaryLogarithm()

--- a/tests/Algebra/ComplexNumberTest.php
+++ b/tests/Algebra/ComplexNumberTest.php
@@ -167,8 +167,8 @@ class ComplexNumberTest extends TestCase
         $this->assertInstanceOf(ComplexNumber::class, $squareRoot);
         $this->assertNotSame($number, $squareRoot);
         $this->assertSame('(3 + 4i)', $number->toString());
-        $this->assertSame(2.0, $squareRoot->real()->value());
-        $this->assertSame(1.0, $squareRoot->imaginary()->value());
+        $this->assertSame(2, $squareRoot->real()->value());
+        $this->assertSame(1, $squareRoot->imaginary()->value());
         $this->assertSame(
             '((√((3 + (√((3^2) + (4^2)))) ÷ 2)) + (sgn(4) x (√(((-1 x 3) + (√((3^2) + (4^2)))) ÷ 2)))i)',
             $squareRoot->toString(),

--- a/tests/Algebra/DivisionTest.php
+++ b/tests/Algebra/DivisionTest.php
@@ -88,7 +88,7 @@ class DivisionTest extends TestCase
         $division = Number::of(6.66)->divideBy(Number::of(3));
         $number = $division->floor();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testCeil()
@@ -104,7 +104,7 @@ class DivisionTest extends TestCase
         $division = Number::of(9)->divideBy(Number::of(3));
         $number = $division->modulo(Number::of(2));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testAbsolute()
@@ -128,7 +128,7 @@ class DivisionTest extends TestCase
         $division = Number::of(8)->divideBy(Number::of(2));
         $number = $division->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/FactorialTest.php
+++ b/tests/Algebra/FactorialTest.php
@@ -94,7 +94,7 @@ class FactorialTest extends TestCase
         $number = Factorial::of(3)->number();
         $number = $number->modulo(Number::of(4));
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testAbsolute()

--- a/tests/Algebra/FactorialTest.php
+++ b/tests/Algebra/FactorialTest.php
@@ -6,20 +6,12 @@ namespace Tests\Innmind\Math\Algebra;
 use Innmind\Math\{
     Algebra\Factorial,
     Algebra\Number,
-    Exception\FactorialMustBePositive
 };
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class FactorialTest extends TestCase
 {
-    public function testThrowWhenNegativeFactorial()
-    {
-        $this->expectException(FactorialMustBePositive::class);
-
-        Factorial::of(-1);
-    }
-
     public function testStringCast()
     {
         $number = Factorial::of(3);

--- a/tests/Algebra/FloorTest.php
+++ b/tests/Algebra/FloorTest.php
@@ -102,7 +102,7 @@ class FloorTest extends TestCase
         $floor = Number::of(42.45)->floor();
         $number = $floor->modulo(Number::of(20));
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testAbsolute()
@@ -118,7 +118,7 @@ class FloorTest extends TestCase
         $floor = Number::of(2.5)->floor();
         $number = $floor->power(Number::of(2));
 
-        $this->assertSame(4.0, $number->value());
+        $this->assertSame(4, $number->value());
     }
 
     public function testSquareRoot()
@@ -126,7 +126,7 @@ class FloorTest extends TestCase
         $floor = Number::of(4.5)->floor();
         $number = $floor->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/IntegerTest.php
+++ b/tests/Algebra/IntegerTest.php
@@ -92,7 +92,7 @@ class IntegerTest extends TestCase
         $number = Number::of(3);
         $number = $number->modulo(Number::of(2));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testAbsolute()
@@ -116,7 +116,7 @@ class IntegerTest extends TestCase
         $number = Number::of(4);
         $number = $number->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/ModuloTest.php
+++ b/tests/Algebra/ModuloTest.php
@@ -115,7 +115,7 @@ class ModuloTest extends TestCase
         );
         $number = $modulo->floor();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testCeil()
@@ -125,7 +125,7 @@ class ModuloTest extends TestCase
         );
         $number = $modulo->ceil();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testModulo()
@@ -159,7 +159,7 @@ class ModuloTest extends TestCase
         );
         $number = $modulo->power(Number::of(2));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testSquareRoot()
@@ -169,7 +169,7 @@ class ModuloTest extends TestCase
         );
         $number = $modulo->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/MultiplicationTest.php
+++ b/tests/Algebra/MultiplicationTest.php
@@ -124,7 +124,7 @@ class MultiplicationTest extends TestCase
         );
         $number = $multiplication->modulo(Number::of(2));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testAbsolute()
@@ -154,7 +154,7 @@ class MultiplicationTest extends TestCase
         );
         $number = $multiplication->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/NaturalLogarithmTest.php
+++ b/tests/Algebra/NaturalLogarithmTest.php
@@ -30,14 +30,14 @@ class NaturalLogarithmTest extends TestCase
     {
         $ln = Number::of(1)->apply(Logarithm::natural);
 
-        $this->assertSame(0.0, $ln->value());
+        $this->assertSame(0, $ln->value());
     }
 
     public function testValue()
     {
         $ln = Number::of(1)->apply(Logarithm::natural);
 
-        $this->assertSame(0.0, $ln->value());
+        $this->assertSame(0, $ln->value());
     }
 
     public function testStringCast()
@@ -69,7 +69,7 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->add(Number::of(7));
 
-        $this->assertSame(7.0, $number->value());
+        $this->assertSame(7, $number->value());
     }
 
     public function testSubtract()
@@ -77,7 +77,7 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->subtract(Number::of(7));
 
-        $this->assertSame(-7.0, $number->value());
+        $this->assertSame(-7, $number->value());
     }
 
     public function testMultiplication()
@@ -85,7 +85,7 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->multiplyBy(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testDivision()
@@ -93,7 +93,7 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->divideBy(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testFloor()
@@ -101,7 +101,7 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->floor();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testCeil()
@@ -109,7 +109,7 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->ceil();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testAbsolute()
@@ -125,7 +125,7 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->modulo(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testPower()
@@ -133,7 +133,7 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->power(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testSquareRoot()
@@ -141,14 +141,14 @@ class NaturalLogarithmTest extends TestCase
         $ln = Number::of(1)->apply(Logarithm::natural);
         $number = $ln->squareRoot();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testExponential()
     {
         $number = Number::of(1)->apply(Logarithm::natural)->exponential();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testBinaryLogarithm()

--- a/tests/Algebra/Number/ETest.php
+++ b/tests/Algebra/Number/ETest.php
@@ -67,7 +67,7 @@ class ETest extends TestCase
         $number = Number::e();
         $number = $number->floor();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testCeil()

--- a/tests/Algebra/PowerTest.php
+++ b/tests/Algebra/PowerTest.php
@@ -133,7 +133,7 @@ class PowerTest extends TestCase
         );
         $number = $power->modulo(Number::of(0.5));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testAbsolute()
@@ -163,7 +163,7 @@ class PowerTest extends TestCase
         );
         $number = $power->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/RealTest.php
+++ b/tests/Algebra/RealTest.php
@@ -127,7 +127,7 @@ class RealTest extends TestCase
         $number = Number::of(3);
         $number = $number->modulo(Number::of(2));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testAbsolute()
@@ -151,7 +151,7 @@ class RealTest extends TestCase
         $number = Number::of(4);
         $number = $number->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/RoundTest.php
+++ b/tests/Algebra/RoundTest.php
@@ -128,7 +128,7 @@ class RoundTest extends TestCase
         $round = Number::of(4.3)->roundUp();
         $number = $round->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/SignumTest.php
+++ b/tests/Algebra/SignumTest.php
@@ -94,7 +94,7 @@ class SignumTest extends TestCase
         $sgn = Number::of(2)->signum();
         $number = $sgn->floor();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testCeil()
@@ -102,7 +102,7 @@ class SignumTest extends TestCase
         $sgn = Number::of(2)->signum();
         $number = $sgn->ceil();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testModulo()
@@ -110,7 +110,7 @@ class SignumTest extends TestCase
         $sgn = Number::of(2)->signum();
         $number = $sgn->modulo(Number::of(0.5));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testAbsolute()
@@ -134,7 +134,7 @@ class SignumTest extends TestCase
         $sgn = Number::of(2)->signum();
         $number = $sgn->squareRoot();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/SquareRootTest.php
+++ b/tests/Algebra/SquareRootTest.php
@@ -19,14 +19,14 @@ class SquareRootTest extends TestCase
     {
         $sqrt = Number::of(4)->squareRoot();
 
-        $this->assertSame(2.0, $sqrt->value());
+        $this->assertSame(2, $sqrt->value());
     }
 
     public function testValue()
     {
         $sqrt = Number::of(4)->squareRoot();
 
-        $this->assertSame(2.0, $sqrt->value());
+        $this->assertSame(2, $sqrt->value());
     }
 
     public function testStringCast()
@@ -58,7 +58,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(4)->squareRoot();
         $number = $sqrt->add(Number::of(7));
 
-        $this->assertSame(9.0, $number->value());
+        $this->assertSame(9, $number->value());
     }
 
     public function testSubtract()
@@ -66,7 +66,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(4)->squareRoot();
         $number = $sqrt->subtract(Number::of(7));
 
-        $this->assertSame(-5.0, $number->value());
+        $this->assertSame(-5, $number->value());
     }
 
     public function testMultiplication()
@@ -74,7 +74,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(4)->squareRoot();
         $number = $sqrt->multiplyBy(Number::of(2));
 
-        $this->assertSame(4.0, $number->value());
+        $this->assertSame(4, $number->value());
     }
 
     public function testDivision()
@@ -82,7 +82,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(4)->squareRoot();
         $number = $sqrt->divideBy(Number::of(2));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testFloor()
@@ -90,7 +90,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(2)->squareRoot();
         $number = $sqrt->floor();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testCeil()
@@ -98,7 +98,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(2)->squareRoot();
         $number = $sqrt->ceil();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testAbsolute()
@@ -106,7 +106,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(4)->squareRoot();
         $number = $sqrt->absolute();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testModulo()
@@ -114,7 +114,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(4)->squareRoot();
         $number = $sqrt->modulo(Number::of(2));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testPower()
@@ -122,7 +122,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(4)->squareRoot();
         $number = $sqrt->power(Number::of(2));
 
-        $this->assertSame(4.0, $number->value());
+        $this->assertSame(4, $number->value());
     }
 
     public function testSquareRoot()
@@ -130,7 +130,7 @@ class SquareRootTest extends TestCase
         $sqrt = Number::of(16)->squareRoot();
         $number = $sqrt->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Algebra/SubtractionTest.php
+++ b/tests/Algebra/SubtractionTest.php
@@ -124,7 +124,7 @@ class SubtractionTest extends TestCase
         );
         $number = $subtraction->modulo(Number::of(6));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testAbsolute()
@@ -154,7 +154,7 @@ class SubtractionTest extends TestCase
         );
         $number = $subtraction->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()

--- a/tests/Geometry/Trigonometry/ArcCosineTest.php
+++ b/tests/Geometry/Trigonometry/ArcCosineTest.php
@@ -162,7 +162,7 @@ class ArcCosineTest extends TestCase
             ->number();
         $number = $acos->modulo(Number::of(3));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testAbsolute()

--- a/tests/Geometry/Trigonometry/ArcSineTest.php
+++ b/tests/Geometry/Trigonometry/ArcSineTest.php
@@ -162,7 +162,7 @@ class ArcSineTest extends TestCase
             ->number();
         $number = $asin->modulo(Number::of(3));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testAbsolute()

--- a/tests/Geometry/Trigonometry/ArcTangentTest.php
+++ b/tests/Geometry/Trigonometry/ArcTangentTest.php
@@ -162,7 +162,7 @@ class ArcTangentTest extends TestCase
             ->number();
         $number = $atan->modulo(Number::of(3));
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testAbsolute()

--- a/tests/Geometry/Trigonometry/CosineTest.php
+++ b/tests/Geometry/Trigonometry/CosineTest.php
@@ -85,7 +85,7 @@ class CosineTest extends TestCase
         $cos = Degree::of(Number::of(42))->cosine();
         $number = $cos->floor();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testCeil()
@@ -93,7 +93,7 @@ class CosineTest extends TestCase
         $cos = Degree::of(Number::of(42))->cosine();
         $number = $cos->ceil();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testModulo()

--- a/tests/Geometry/Trigonometry/SineTest.php
+++ b/tests/Geometry/Trigonometry/SineTest.php
@@ -85,7 +85,7 @@ class SineTest extends TestCase
         $sin = Degree::of(Number::of(42))->sine();
         $number = $sin->floor();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testCeil()
@@ -93,7 +93,7 @@ class SineTest extends TestCase
         $sin = Degree::of(Number::of(42))->sine();
         $number = $sin->ceil();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testModulo()

--- a/tests/Geometry/Trigonometry/TangentTest.php
+++ b/tests/Geometry/Trigonometry/TangentTest.php
@@ -85,7 +85,7 @@ class TangentTest extends TestCase
         $tan = Degree::of(Number::of(42))->tangent();
         $number = $tan->floor();
 
-        $this->assertSame(0.0, $number->value());
+        $this->assertSame(0, $number->value());
     }
 
     public function testCeil()
@@ -93,7 +93,7 @@ class TangentTest extends TestCase
         $tan = Degree::of(Number::of(42))->tangent();
         $number = $tan->ceil();
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testModulo()

--- a/tests/Polynom/PolynomTest.php
+++ b/tests/Polynom/PolynomTest.php
@@ -81,7 +81,7 @@ class PolynomTest extends TestCase
                 ->polynom(),
         );
         $this->assertSame(
-            4.0,
+            4,
             $polynom->tangent(Number::of(2))(Number::of(2))->value(),
         );
     }

--- a/tests/Polynom/TangentTest.php
+++ b/tests/Polynom/TangentTest.php
@@ -29,7 +29,7 @@ class TangentTest extends TestCase
         $this->assertSame($abscissa, $tangent->abscissa());
         $this->assertInstanceOf(Number::class, $tangent(Number::of(0)));
         $this->assertSame(
-            4.0,
+            4,
             $tangent(Number::of(2))->value(),
         );
     }

--- a/tests/Regression/PolynomialRegressionTest.php
+++ b/tests/Regression/PolynomialRegressionTest.php
@@ -33,7 +33,7 @@ class PolynomialRegressionTest extends TestCase
             static fn() => true,
             static fn() => false,
         ));
-        $this->assertSame(1.0, $polynom->degree(2)->match(
+        $this->assertSame(1, $polynom->degree(2)->match(
             static fn($degree) => $degree->coeff()->value(),
             static fn() => null,
         ));

--- a/tests/Statistics/MeanTest.php
+++ b/tests/Statistics/MeanTest.php
@@ -142,7 +142,7 @@ class MeanTest extends TestCase
         )->result();
         $number = $mean->modulo(Number::of(3));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testAbsolute()
@@ -175,7 +175,7 @@ class MeanTest extends TestCase
         )->result();
         $number = $mean->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()
@@ -198,7 +198,7 @@ class MeanTest extends TestCase
             ->result()
             ->apply(Logarithm::binary);
 
-        $this->assertSame(\log(4, 2), $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testNaturalLogarithm()

--- a/tests/Statistics/MedianTest.php
+++ b/tests/Statistics/MedianTest.php
@@ -164,7 +164,7 @@ class MedianTest extends TestCase
         )->result();
         $number = $median->modulo(Number::of(3));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testAbsolute()
@@ -197,7 +197,7 @@ class MedianTest extends TestCase
         )->result();
         $number = $median->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()
@@ -220,7 +220,7 @@ class MedianTest extends TestCase
             ->result()
             ->apply(Logarithm::binary);
 
-        $this->assertSame(\log(4, 2), $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testNaturalLogarithm()

--- a/tests/Statistics/ScopeTest.php
+++ b/tests/Statistics/ScopeTest.php
@@ -142,7 +142,7 @@ class ScopeTest extends TestCase
         )->result();
         $number = $scope->modulo(Number::of(5));
 
-        $this->assertSame(1.0, $number->value());
+        $this->assertSame(1, $number->value());
     }
 
     public function testAbsolute()
@@ -175,7 +175,7 @@ class ScopeTest extends TestCase
         )->result();
         $number = $scope->squareRoot();
 
-        $this->assertSame(2.0, $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testExponential()
@@ -198,7 +198,7 @@ class ScopeTest extends TestCase
             ->result()
             ->apply(Logarithm::binary);
 
-        $this->assertSame(\log(4, 2), $number->value());
+        $this->assertSame(2, $number->value());
     }
 
     public function testNaturalLogarithm()


### PR DESCRIPTION
This PR was an attempt to bring type safety to algebra but it failed to do so so far. 

The first approach was to return `Attempt`s on operations that may fail like a division. This brought 2 problems:

- this makes chaining operations very difficult and thus poor developer experience
- this prevents lazy evaluation of operations

The second approach was to silently accept any operation and to return `Attempt`s when truly computing numbers, like a monad. But this also brought a poor design as `Attempt`s were rippling everywhere in the codebase. A simple example is the equality signature is `equals(Number): Attempt<bool>`.

Until a new approach is found, the error handling will stay as is.

---

Even though the original goal failed this brings code deduplication that will help implement #6.